### PR TITLE
Add partner UI and privacy toggle handler

### DIFF
--- a/app/services.py
+++ b/app/services.py
@@ -426,8 +426,6 @@ def get_accountability_partner_cards(user):
                     if latest_challenge
                     else None
                 ),
-                
-                "difficulty": DEFAULT_DIFFICULTY,
             }
         )
 

--- a/app/templates/community.html
+++ b/app/templates/community.html
@@ -9,7 +9,6 @@
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800&display=swap" rel="stylesheet">
   <link rel="stylesheet" href="{{ url_for('static', filename='css/community.css') }}">
-  <script src="{{ url_for('static', filename='js/community.js') }}" defer></script>
 </head>
 <body>
   <div class="page-bg"></div>
@@ -108,8 +107,8 @@
 
         <article class="summary-card card-green">
           <p class="summary-label">Accountability Circle</p>
-          <h3>Coming Soon</h3>
-          <span>Partner system in progress</span>
+          <h3>{{ partners | length }}</h3>
+          <span>Active partner links</span>
         </article>
 
         <article class="summary-card card-blue">
@@ -145,6 +144,9 @@
                               Level {{ user.progress.level }}
                             </span>
                           {% endif %}
+                          {% if user.id == current_user.id %}
+                            <span class="status-badge support">You</span>
+                          {% endif %}
                         </div>
                         {% if user.progress %}
                           <p class="partner-meta">
@@ -156,12 +158,70 @@
                         {% endif %}
                       </div>
                     </div>
+                    {% if user.id != current_user.id %}
+                      <div class="partner-actions">
+                        <form method="post" action="{{ url_for('main.add_partner') }}">
+                          <input type="hidden" name="partner_identifier" value="{{ user.username }}">
+                          <button type="submit" class="primary-btn">Add Partner</button>
+                        </form>
+                      </div>
+                    {% endif %}
                   </div>
                 {% endfor %}
               {% else %}
-                <p style="color: var(--muted);">
-                  🏜️ The public leaderboard is empty. Be the first to share your progress!
-                </p>
+                <div class="empty-state">
+                  <p class="partner-text">The public leaderboard is empty.</p>
+                  <p class="partner-meta">Be the first to share your progress in Settings.</p>
+                </div>
+              {% endif %}
+            </div>
+          </article>
+
+          <article class="panel">
+            <div class="panel-heading-row">
+              <div>
+                <p class="panel-kicker">CIRCLE</p>
+                <h3 class="panel-heading">Your current partners</h3>
+              </div>
+            </div>
+
+            <div class="partner-list">
+              {% if partners %}
+                {% for partner in partners %}
+                  <div class="partner-card">
+                    <div class="partner-main">
+                      <div class="avatar avatar-green">
+                        {{ partner.username[0] | upper }}
+                      </div>
+                      <div class="partner-info">
+                        <div class="name-row">
+                          <h4>{{ partner.username }}</h4>
+                          {% if partner.current_challenge %}
+                            <span class="status-badge support">
+                              {{ partner.current_challenge }}
+                            </span>
+                          {% endif %}
+                        </div>
+                        <p class="partner-meta">
+                          Streak: {{ partner.streak }} days • Level {{ partner.level }} • XP {{ partner.xp }}
+                        </p>
+                        <p class="partner-text">
+                          HP {{ partner.hp }}/{{ partner.max_hp }}
+                        </p>
+                      </div>
+                    </div>
+                    <div class="partner-actions">
+                      <form method="post" action="{{ url_for('main.remove_partner', partner_id=partner.id) }}">
+                        <button type="submit" class="action-btn red">Remove</button>
+                      </form>
+                    </div>
+                  </div>
+                {% endfor %}
+              {% else %}
+                <div class="empty-state">
+                  <p class="partner-text">No partners yet.</p>
+                  <p class="partner-meta">Add someone from the public list to build your circle.</p>
+                </div>
               {% endif %}
             </div>
           </article>
@@ -172,16 +232,14 @@
             <p class="panel-kicker">INVITE</p>
             <h3 class="panel-heading">Add accountability partner</h3>
 
-            <label class="input-label" for="partner-name">Partner name</label>
-            <input id="partner-name" class="text-input" type="text"
-              placeholder="Enter name">
+            <form method="post" action="{{ url_for('main.add_partner') }}">
+              <label class="input-label" for="partner-identifier">Partner ID / Username</label>
+              <input id="partner-identifier" class="text-input" name="partner_identifier" type="text"
+                placeholder="Enter username or email" required>
 
-            <label class="input-label" for="partner-code">Partner ID / Username</label>
-            <input id="partner-code" class="text-input" type="text"
-              placeholder="Enter ID">
-
-            <button id="invite-btn" class="primary-btn">Send Invite</button>
-            <p id="invite-status" class="invite-status"></p>
+              <button type="submit" class="primary-btn">Add Partner</button>
+            </form>
+            <p class="invite-status">Only public users can be added to your accountability circle.</p>
           </article>
         </div>
       </section>

--- a/app/templates/community.html
+++ b/app/templates/community.html
@@ -161,6 +161,7 @@
                     {% if user.id != current_user.id %}
                       <div class="partner-actions">
                         <form method="post" action="{{ url_for('main.add_partner') }}">
+                          <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
                           <input type="hidden" name="partner_identifier" value="{{ user.username }}">
                           <button type="submit" class="primary-btn">Add Partner</button>
                         </form>
@@ -212,6 +213,7 @@
                     </div>
                     <div class="partner-actions">
                       <form method="post" action="{{ url_for('main.remove_partner', partner_id=partner.id) }}">
+                        <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
                         <button type="submit" class="action-btn red">Remove</button>
                       </form>
                     </div>
@@ -233,6 +235,7 @@
             <h3 class="panel-heading">Add accountability partner</h3>
 
             <form method="post" action="{{ url_for('main.add_partner') }}">
+              <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
               <label class="input-label" for="partner-identifier">Partner ID / Username</label>
               <input id="partner-identifier" class="text-input" name="partner_identifier" type="text"
                 placeholder="Enter username or email" required>

--- a/app/templates/settings.html
+++ b/app/templates/settings.html
@@ -9,6 +9,7 @@
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800&display=swap" rel="stylesheet">
   <link rel="stylesheet" href="{{ url_for('static', filename='css/settings.css') }}">
+  <script src="{{ url_for('static', filename='js/settings.js') }}" defer></script>
 </head>
 <body>
   <div class="page-bg"></div>
@@ -125,30 +126,31 @@
             <h3 class="panel-heading">Visibility controls</h3>
             <p class="panel-subheading">Privacy Settings</p>
 
-            <div class="toggle-list">
-              <label class="toggle-row">
-                <div>
-                  <p class="toggle-title">Share progress with partners</p>
-                  <p class="toggle-sub">
-                    Allow your accountability circle to view your progress.
-                    Currently: {{ "Public" if current_user.is_public else "Private" }}.
-                    Change this in the dashboard challenge form.
-                  </p>
-                </div>
-                <input class="toggle-input" type="checkbox"
-                  {{ "checked" if current_user.is_public else "" }} disabled>
-              </label>
+            <form id="privacy-form" method="post" action="{{ url_for('main.settings') }}">
+              <div class="toggle-list">
+                <label class="toggle-row" for="privacy-toggle">
+                  <div>
+                    <p class="toggle-title">Share progress with partners</p>
+                    <p class="toggle-sub">
+                      Allow your accountability circle to view your progress.
+                      Currently: {{ "Public" if current_user.is_public else "Private" }}.
+                    </p>
+                  </div>
+                  <input id="privacy-toggle" name="is_public" class="toggle-input" type="checkbox"
+                    {{ "checked" if current_user.is_public else "" }}>
+                </label>
 
-              <label class="toggle-row">
-                <div>
-                  <p class="toggle-title">Show activity status</p>
-                  <p class="toggle-sub">
-                    Let others see whether you completed today's tasks.
-                  </p>
-                </div>
-                <input id="privacy-status" class="toggle-input" type="checkbox">
-              </label>
-            </div>
+                <label class="toggle-row">
+                  <div>
+                    <p class="toggle-title">Show activity status</p>
+                    <p class="toggle-sub">
+                      Let others see whether you completed today's tasks.
+                    </p>
+                  </div>
+                  <input id="privacy-status" class="toggle-input" type="checkbox" disabled>
+                </label>
+              </div>
+            </form>
           </article>
 
           <article class="panel">

--- a/app/templates/settings.html
+++ b/app/templates/settings.html
@@ -127,6 +127,7 @@
             <p class="panel-subheading">Privacy Settings</p>
 
             <form id="privacy-form" method="post" action="{{ url_for('main.settings') }}">
+              <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
               <div class="toggle-list">
                 <label class="toggle-row" for="privacy-toggle">
                   <div>

--- a/static/css/community.css
+++ b/static/css/community.css
@@ -444,6 +444,10 @@ body {
   flex-wrap: wrap;
 }
 
+.partner-actions form {
+  margin: 0;
+}
+
 .action-btn,
 .primary-btn {
   border: none;
@@ -546,6 +550,15 @@ body {
 .primary-btn {
   width: 100%;
   background: linear-gradient(180deg, #8c5cf6, #7648db);
+}
+
+.partner-actions .primary-btn,
+.partner-actions .action-btn {
+  width: auto;
+}
+
+.empty-state {
+  padding: 4px 2px;
 }
 
 .invite-status {

--- a/static/js/community.js
+++ b/static/js/community.js
@@ -1,10 +1,3 @@
-
-const partnerCards = document.querySelectorAll(".partner-card");
-const inviteBtn = document.getElementById("invite-btn");
-const inviteStatus = document.getElementById("invite-status");
-const partnerNameInput = document.getElementById("partner-name");
-const partnerCodeInput = document.getElementById("partner-code");
-
 const partyMembers = [
   { name: "Wooji", streak: 12, mode: "Warrior" },  // slot 1 — party leader
   { name: "Alex", streak: 9, mode: "Sage" },         // slot 2 — joined second
@@ -49,39 +42,3 @@ function renderParty() {
 }
 
 renderParty();
-
-document.querySelectorAll("[data-action]").forEach(button => {
-  button.addEventListener("click", () => {
-    const action = button.dataset.action;
-    const name = button.dataset.name;
-
-    if (action === "support") {
-      addLogItem(`You sent support to ${name}.`);
-    }
-
-    if (action === "nudge") {
-      addLogItem(`You sent a gentle nudge to ${name}.`);
-    }
-
-    if (action === "view") {
-      addLogItem(`You viewed ${name}'s recent progress.`);
-    }
-  });
-});
-
-inviteBtn.addEventListener("click", () => {
-  const name = partnerNameInput.value.trim();
-  const code = partnerCodeInput.value.trim();
-
-  if (!name || !code) {
-    inviteStatus.textContent = "Please fill in both fields.";
-    inviteStatus.style.color = "#f0a86b";
-    return;
-  }
-
-  inviteStatus.textContent = `Invite sent to ${name}.`;
-  inviteStatus.style.color = "#8fd7a2";
-
-  partnerNameInput.value = "";
-  partnerCodeInput.value = "";
-});

--- a/static/js/settings.js
+++ b/static/js/settings.js
@@ -1,1 +1,8 @@
-/** all removed as entire file was localStorage based*/
+const privacyForm = document.getElementById("privacy-form");
+const privacyToggle = document.getElementById("privacy-toggle");
+
+if (privacyForm && privacyToggle) {
+	privacyToggle.addEventListener("change", () => {
+		privacyForm.submit();
+	});
+}


### PR DESCRIPTION
Introduce server-driven partner management and privacy controls. Updates include:

- app/templates/community.html: Replace static invite widgets with server-backed forms and panels (public leaderboard, add/remove partner actions, partner circle panel, improved empty states). Remove client-side community.js include.
- app/templates/settings.html: Wrap visibility controls in a POST form, add a checkbox to toggle `is_public`, and include settings.js to handle auto-submit.
- app/services.py: Remove unused default `difficulty` field from partner card payload.
- static/css/community.css: Add styling for partner-actions, empty-state, and button sizing.
- static/js/community.js: Strip obsolete demo/invite client logic, leaving party render data only.
- static/js/settings.js: Add script to auto-submit the privacy form when the toggle changes.

These changes move partner add/remove and privacy toggling to server-side handling (POST to `main.add_partner`, `main.remove_partner`, and `main.settings`) and remove redundant client-side invite handling.