### PR TITLE
Display role icons for users and add avatar styles

### DIFF
--- a/app/templates/base.html
+++ b/app/templates/base.html
@@ -22,7 +22,25 @@
                     <a href="{{ url_for('main.challenge') }}">Challenge</a>
                     <a href="{{ url_for('main.community') }}">Community</a>
                     <a href="{{ url_for('main.settings') }}">Settings</a>
-                    <span style="color: #9ca3af;">{{ current_user.username }}</span>
+                                        {% set mode = current_user.current_challenge if current_user.current_challenge else "Unknown" %}
+                                        {% set mode_lower = mode | lower %}
+
+                                        {% if mode_lower == "warrior" %}
+                                            {% set icon_file = "img/icons/warrior.png" %}
+                                        {% elif mode_lower == "sage" %}
+                                            {% set icon_file = "img/icons/sage.png" %}
+                                        {% elif mode_lower == "demon" %}
+                                            {% set icon_file = "img/icons/demon.png" %}
+                                        {% else %}
+                                            {% set icon_file = "img/icons/Shadow.png" %}
+                                        {% endif %}
+
+                                                                                {% if mode_lower in ['warrior','sage','demon'] %}
+                                                                                    <img class="nav-avatar" src="{{ url_for('static', filename=icon_file) }}" alt="{{ mode }}">
+                                                                                {% else %}
+                                                                                    <span class="nav-avatar-initials">{{ current_user.username[0] | upper }}</span>
+                                                                                {% endif %}
+                                                                                <span style="color: #9ca3af;">{{ current_user.username }}</span>
                     <a href="{{ url_for('main.logout') }}" style="color: #ef4444;">Logout</a>
                 {% else %}
                     <a href="{{ url_for('main.home') }}">Home</a>

--- a/app/templates/community.html
+++ b/app/templates/community.html
@@ -149,8 +149,25 @@
 
                   <div class="partner-card">
                     <div class="partner-main">
+                      {% set mode = user.current_challenge if user.current_challenge else "Unknown" %}
+                      {% set mode_lower = mode | lower %}
+
+                      {% if mode_lower == "warrior" %}
+                        {% set icon_file = "img/icons/warrior.png" %}
+                      {% elif mode_lower == "sage" %}
+                        {% set icon_file = "img/icons/sage.png" %}
+                      {% elif mode_lower == "demon" %}
+                        {% set icon_file = "img/icons/demon.png" %}
+                      {% else %}
+                        {% set icon_file = "img/icons/Shadow.png" %}
+                      {% endif %}
+
                       <div class="avatar avatar-purple">
-                        {{ user.username[0] | upper }}
+                        {% if mode_lower in ['warrior','sage','demon'] %}
+                          <img class="avatar-img" src="{{ url_for('static', filename=icon_file) }}" alt="{{ mode }}">
+                        {% else %}
+                          {{ user.username[0] | upper }}
+                        {% endif %}
                       </div>
 
                       <div class="partner-info">
@@ -209,8 +226,25 @@
                 {% for partner in partner_list %}
                   <div class="partner-card">
                     <div class="partner-main">
+                      {% set mode = partner.current_challenge if partner.current_challenge else "Unknown" %}
+                      {% set mode_lower = mode | lower %}
+
+                      {% if mode_lower == "warrior" %}
+                        {% set icon_file = "img/icons/warrior.png" %}
+                      {% elif mode_lower == "sage" %}
+                        {% set icon_file = "img/icons/sage.png" %}
+                      {% elif mode_lower == "demon" %}
+                        {% set icon_file = "img/icons/demon.png" %}
+                      {% else %}
+                        {% set icon_file = "img/icons/Shadow.png" %}
+                      {% endif %}
+
                       <div class="avatar avatar-green">
-                        {{ partner.username[0] | upper }}
+                        {% if mode_lower in ['warrior','sage','demon'] %}
+                          <img class="avatar-img" src="{{ url_for('static', filename=icon_file) }}" alt="{{ mode }}">
+                        {% else %}
+                          {{ partner.username[0] | upper }}
+                        {% endif %}
                       </div>
 
                       <div class="partner-info">

--- a/static/css/community.css
+++ b/static/css/community.css
@@ -382,6 +382,14 @@ body {
   flex-shrink: 0;
 }
 
+.avatar-img {
+  width: 40px;
+  height: 40px;
+  border-radius: 10px;
+  object-fit: cover;
+  display: block;
+}
+
 .avatar-purple {
   background: var(--purple-soft);
   color: #d8c6ff;

--- a/static/css/style.css
+++ b/static/css/style.css
@@ -95,6 +95,28 @@ nav {
     align-items: center;
 }
 
+.nav-avatar {
+    width: 28px;
+    height: 28px;
+    border-radius: 6px;
+    object-fit: cover;
+    margin-right: 8px;
+    vertical-align: middle;
+}
+
+.nav-avatar-initials {
+    width: 28px;
+    height: 28px;
+    border-radius: 6px;
+    display: inline-grid;
+    place-items: center;
+    background: #374151;
+    color: #d1d5db;
+    font-weight: 700;
+    margin-right: 8px;
+    font-size: 0.85rem;
+}
+
 nav a {
     color: #d1d5db;
     text-decoration: none;


### PR DESCRIPTION
Render role-specific icons (warrior, sage, demon) in place of initials when users have a current_challenge, with a Shadow.png fallback; otherwise show the user's initial. Updated templates (app/templates/base.html, app/templates/community.html) to choose icon files based on lowercased current_challenge and to render images for navbar avatars and partner cards (including partner_list). Added styling for .avatar-img, .nav-avatar and .nav-avatar-initials in static/css/community.css and static/css/style.css to size, round and align the new avatar images/initials.