### PR TITLE
Display auth flash messages with styles

### DIFF
--- a/app/routes.py
+++ b/app/routes.py
@@ -87,6 +87,7 @@ def login():
             next_page = request.args.get("next")
             return redirect(next_page or url_for("main.dashboard"))
 
+        form.password.errors.append("Incorrect username or password.")
         flash("Invalid username or password.", "error")
 
     return render_template("login.html", form=form)

--- a/app/templates/login.html
+++ b/app/templates/login.html
@@ -27,6 +27,16 @@
         <h2>Welcome Back</h2>
         <p class="screen-subtitle">Continue the journey you started.</p>
 
+        {% with messages = get_flashed_messages(with_categories=true) %}
+          {% if messages %}
+            <div class="auth-messages" role="alert" aria-live="polite">
+              {% for category, message in messages %}
+                <p class="auth-message auth-message-{{ category }}">{{ message }}</p>
+              {% endfor %}
+            </div>
+          {% endif %}
+        {% endwith %}
+
         <label for="login-username">Username</label>
         {{ form.username(id="login-username", class="nes-input", placeholder="Enter Username") }}
         {% for error in form.username.errors %}

--- a/app/templates/signup.html
+++ b/app/templates/signup.html
@@ -27,6 +27,16 @@
         <h2>Create Account</h2>
         <p class="screen-subtitle">Begin the path with discipline and intention.</p>
 
+        {% with messages = get_flashed_messages(with_categories=true) %}
+          {% if messages %}
+            <div class="auth-messages" role="alert" aria-live="polite">
+              {% for category, message in messages %}
+                <p class="auth-message auth-message-{{ category }}">{{ message }}</p>
+              {% endfor %}
+            </div>
+          {% endif %}
+        {% endwith %}
+
         <label for="signup-username">Username</label>
         {{ form.username(id="signup-username", class="nes-input", placeholder="Enter Username") }}
         {% for error in form.username.errors %}

--- a/static/css/authlogin.css
+++ b/static/css/authlogin.css
@@ -51,6 +51,40 @@ body {
   backdrop-filter: blur(2px);
 }
 
+.auth-messages {
+  margin: 0 0 16px;
+}
+
+.auth-message {
+  margin: 0 0 10px;
+  padding: 12px 14px;
+  border: 2px solid #111;
+  font-family: inherit;
+  font-size: 0.55rem;
+  line-height: 1.7;
+  background: #fff8e1;
+  color: #1f2937;
+}
+
+.auth-message:last-child {
+  margin-bottom: 0;
+}
+
+.auth-message-success {
+  background: #dcfce7;
+  border-color: #16a34a;
+}
+
+.auth-message-error {
+  background: #fee2e2;
+  border-color: #dc2626;
+}
+
+.auth-message-info {
+  background: #dbeafe;
+  border-color: #2563eb;
+}
+
 .screen-subtitle {
   font-size: 0.55rem;
   line-height: 1.7;

--- a/static/css/authsignup.css
+++ b/static/css/authsignup.css
@@ -72,6 +72,40 @@ body {
   backdrop-filter: blur(2px);
 }
 
+.auth-messages {
+  margin: 0 0 16px;
+}
+
+.auth-message {
+  margin: 0 0 10px;
+  padding: 12px 14px;
+  border: 2px solid #111;
+  font-family: inherit;
+  font-size: 0.55rem;
+  line-height: 1.7;
+  background: #fff8e1;
+  color: #1f2937;
+}
+
+.auth-message:last-child {
+  margin-bottom: 0;
+}
+
+.auth-message-success {
+  background: #dcfce7;
+  border-color: #16a34a;
+}
+
+.auth-message-error {
+  background: #fee2e2;
+  border-color: #dc2626;
+}
+
+.auth-message-info {
+  background: #dbeafe;
+  border-color: #2563eb;
+}
+
 .screen-subtitle {
   font-size: 0.55rem;
   line-height: 1.7;


### PR DESCRIPTION
Render flashed messages on the login and signup pages and add styles for message variants. Templates now include an accessible alert container (role="alert", aria-live="polite") that iterates get_flashed_messages(with_categories=true). CSS for both auth pages adds .auth-messages and .auth-message variants (success, error, info) for consistent visual treatment. Also append an inline password error in routes.py so authentication failures show on the form field in addition to the flashed message.