### PR TITLE
Add activity visibility dropdown and online status

### DIFF
--- a/app/models.py
+++ b/app/models.py
@@ -21,6 +21,8 @@ class User(db.Model, UserMixin):
     password_hash = db.Column(db.String(255), nullable=False)
 
     is_public = db.Column(db.Boolean, default=True, nullable=False)
+    show_activity_status = db.Column(db.Boolean, nullable=False, default=True)
+    last_seen_at = db.Column(db.DateTime, nullable=True, index=True)
     created_at = db.Column(db.DateTime, default=utc_now, nullable=False)
 
     challenges = db.relationship(

--- a/app/routes.py
+++ b/app/routes.py
@@ -502,3 +502,40 @@ def remove_partner(partner_id):
         flash("Could not remove accountability partner. Please try again.", "error")
 
     return redirect(url_for("main.community"))
+
+@main.before_app_request
+def update_current_user_last_seen():
+    """Track lightweight last-seen activity for authenticated users."""
+    if not current_user.is_authenticated:
+        return
+
+    if not hasattr(current_user, "last_seen_at"):
+        return
+
+    try:
+        from datetime import datetime, timezone
+
+        now = datetime.now(timezone.utc).replace(tzinfo=None)
+        last_seen = current_user.last_seen_at
+
+        if last_seen is None or (now - last_seen).total_seconds() >= 60:
+            current_user.last_seen_at = now
+            db.session.add(current_user)
+            db.session.commit()
+    except Exception:
+        db.session.rollback()
+
+
+@main.route("/settings/activity-visibility", methods=["POST"])
+@login_required
+def update_activity_visibility():
+    """Update whether the user's online/activity status is visible."""
+    activity_visibility = request.form.get("activity_visibility")
+
+    if activity_visibility in {"online", "hidden"} and hasattr(current_user, "show_activity_status"):
+        current_user.show_activity_status = activity_visibility == "online"
+        db.session.add(current_user)
+        db.session.commit()
+
+    return redirect(url_for("main.settings"))
+

--- a/app/templates/community.html
+++ b/app/templates/community.html
@@ -75,7 +75,7 @@
 
               <div class="party-slot" data-member="{{ loop.index }}">
                 <div class="slot-label">
-                  <p class="slot-name">{{ partner.username }}</p>
+                  <p class="slot-name">{{ partner.username }} {% if partner.show_activity_status %}<span class="activity-dot online" title="Activity visible"></span>{% else %}<span class="activity-dot hidden" title="Hidden mode"></span>{% endif %}</p>
                   <p class="slot-stats">Streak: {{ partner.streak }} days</p>
                 </div>
 
@@ -155,7 +155,7 @@
 
                       <div class="partner-info">
                         <div class="name-row">
-                          <h4>{{ user.username }}</h4>
+                          <h4>{{ user.username }} {% if user.show_activity_status %}<span class="activity-dot online" title="Activity visible"></span>{% else %}<span class="activity-dot hidden" title="Hidden mode"></span>{% endif %}</h4>
 
                           {% if user.progress %}
                             <span class="status-badge complete">
@@ -177,7 +177,7 @@
                     <div class="partner-actions">
                       <form method="post" action="{{ url_for('main.add_partner') }}">
                         <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
-                        <input type="hidden" name="partner_identifier" value="{{ user.username }}">
+                        <input type="hidden" name="partner_identifier" value="{{ user.username }} {% if user.show_activity_status %}<span class="activity-dot online" title="Activity visible"></span>{% else %}<span class="activity-dot hidden" title="Hidden mode"></span>{% endif %}">
                         <button type="submit" class="primary-btn">Add Partner</button>
                       </form>
                     </div>
@@ -215,7 +215,7 @@
 
                       <div class="partner-info">
                         <div class="name-row">
-                          <h4>{{ partner.username }}</h4>
+                          <h4>{{ partner.username }} {% if partner.show_activity_status %}<span class="activity-dot online" title="Activity visible"></span>{% else %}<span class="activity-dot hidden" title="Hidden mode"></span>{% endif %}</h4>
 
                           {% if partner.current_challenge %}
                             <span class="status-badge support">

--- a/app/templates/settings.html
+++ b/app/templates/settings.html
@@ -141,15 +141,37 @@
                     {{ "checked" if current_user.is_public else "" }}>
                 </label>
 
-                <label class="toggle-row">
+                
+              <form id="activity-visibility-form" class="activity-visibility-form" method="post" action="{{ url_for('main.update_activity_visibility') }}">
+                <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
+
+                <label class="activity-visibility-card" for="activity-visibility">
                   <div>
-                    <p class="toggle-title">Show activity status</p>
+                    <p class="toggle-title">Activity visibility</p>
                     <p class="toggle-sub">
-                      Let others see whether you completed today's tasks.
+                      Choose whether others can see your online/activity status.
                     </p>
                   </div>
-                  <input id="privacy-status" class="toggle-input" type="checkbox" disabled>
+
+                  <select id="activity-visibility" name="activity_visibility" class="activity-select" onchange="this.form.submit()">
+                    <option value="online" {% if current_user.show_activity_status %}selected{% endif %}>
+                      Show online status
+                    </option>
+                    <option value="hidden" {% if not current_user.show_activity_status %}selected{% endif %}>
+                      Hidden mode
+                    </option>
+                  </select>
                 </label>
+
+                <p class="activity-helper">
+                  {% if current_user.show_activity_status %}
+                    Your online dot can be shown to public members and accountability partners.
+                  {% else %}
+                    Hidden mode is on. You can still use the app, but others will not see your activity status.
+                  {% endif %}
+                </p>
+              </form>
+
               </div>
             </form>
           </article>

--- a/init_db.py
+++ b/init_db.py
@@ -13,6 +13,7 @@ DEMO_USERS = [
         "username": "demo_public",
         "email": "demo_public@example.com",
         "is_public": True,
+        "show_activity_status": True,
         "hp": 92,
         "max_hp": 100,
         "xp": 840,
@@ -34,6 +35,7 @@ DEMO_USERS = [
         "username": "demo_private",
         "email": "demo_private@example.com",
         "is_public": False,
+        "show_activity_status": False,
         "hp": 64,
         "max_hp": 100,
         "xp": 310,
@@ -52,6 +54,7 @@ DEMO_USERS = [
         "username": "will_campbell",
         "email": "will.campbell@example.com",
         "is_public": True,
+        "show_activity_status": True,
         "hp": 78,
         "max_hp": 100,
         "xp": 430,
@@ -71,6 +74,7 @@ DEMO_USERS = [
         "username": "emily_clarke",
         "email": "emily.clarke@example.com",
         "is_public": True,
+        "show_activity_status": True,
         "hp": 100,
         "max_hp": 100,
         "xp": 1250,
@@ -91,6 +95,7 @@ DEMO_USERS = [
         "username": "noah_nguyen",
         "email": "noah.nguyen@example.com",
         "is_public": True,
+        "show_activity_status": True,
         "hp": 88,
         "max_hp": 100,
         "xp": 670,
@@ -110,6 +115,7 @@ DEMO_USERS = [
         "username": "mia_anderson",
         "email": "mia.anderson@example.com",
         "is_public": True,
+        "show_activity_status": True,
         "hp": 95,
         "max_hp": 100,
         "xp": 980,
@@ -212,6 +218,7 @@ def create_demo_user(user_data):
 
     set_user_password(user, DEMO_PASSWORD)
     set_if_supported(user, "is_public", user_data["is_public"])
+    set_if_supported(user, "show_activity_status", user_data.get("show_activity_status", True))
 
     db.session.add(user)
     db.session.flush()

--- a/static/css/settings.css
+++ b/static/css/settings.css
@@ -458,3 +458,47 @@ body.light-theme .challenge-summary {
     font-size: 1.5rem;
   }
 }
+
+.activity-visibility-form {
+  margin-top: 14px;
+}
+
+.activity-visibility-card {
+  display: flex;
+  justify-content: space-between;
+  gap: 16px;
+  align-items: center;
+  padding: 18px 20px;
+  border-radius: 16px;
+  background: rgba(255, 255, 255, 0.04);
+  border: 1px solid rgba(255, 255, 255, 0.07);
+}
+
+.activity-select {
+  min-width: 190px;
+  padding: 10px 12px;
+  border-radius: 12px;
+  border: 1px solid rgba(255, 255, 255, 0.12);
+  background: #111d2f;
+  color: #edf2ff;
+  font-weight: 700;
+}
+
+.activity-helper {
+  margin: 10px 0 0;
+  color: #9aa8bf;
+  line-height: 1.55;
+  font-size: 0.95rem;
+}
+
+@media (max-width: 720px) {
+  .activity-visibility-card {
+    flex-direction: column;
+    align-items: stretch;
+  }
+
+  .activity-select {
+    width: 100%;
+  }
+}
+

--- a/tests/test_activity_visibility.py
+++ b/tests/test_activity_visibility.py
@@ -1,0 +1,71 @@
+from app.models import User
+
+
+def signup_user(client, username="activityuser", email="activity@example.com"):
+    return client.post(
+        "/signup",
+        data={
+            "username": username,
+            "email": email,
+            "password": "Password123!",
+            "confirm_password": "Password123!",
+        },
+        follow_redirects=True,
+    )
+
+
+def test_settings_activity_visibility_dropdown_renders(client):
+    signup_user(client)
+
+    response = client.get("/settings")
+
+    assert response.status_code == 200
+    assert b'name="activity_visibility"' in response.data
+    assert b"Show online status" in response.data
+    assert b"Hidden mode" in response.data
+
+
+def test_activity_visibility_can_be_hidden_and_enabled(client, app):
+    signup_user(client)
+
+    hidden_response = client.post(
+        "/settings/activity-visibility",
+        data={
+            "is_public": "on",
+            "activity_visibility": "hidden",
+        },
+        follow_redirects=True,
+    )
+
+    assert hidden_response.status_code == 200
+
+    with app.app_context():
+        user = User.query.filter_by(username="activityuser").first()
+        assert user is not None
+        assert user.show_activity_status is False
+
+    online_response = client.post(
+        "/settings/activity-visibility",
+        data={
+            "is_public": "on",
+            "activity_visibility": "online",
+        },
+        follow_redirects=True,
+    )
+
+    assert online_response.status_code == 200
+
+    with app.app_context():
+        user = User.query.filter_by(username="activityuser").first()
+        assert user.show_activity_status is True
+
+
+def test_last_seen_updates_after_request(client, app):
+    signup_user(client, "seenuser", "seen@example.com")
+    client.get("/dashboard")
+
+    with app.app_context():
+        user = User.query.filter_by(username="seenuser").first()
+        assert user is not None
+        assert hasattr(user, "last_seen_at")
+        assert user.last_seen_at is not None


### PR DESCRIPTION
## Summary

This PR replaces the inactive “Show activity status” checkbox with a real Activity Visibility dropdown.

## Changes

- Adds `show_activity_status` to the User model
- Adds `last_seen_at` to track lightweight user activity
- Replaces the dead Settings checkbox with a dropdown:
  - Show online status
  - Hidden mode
- Adds a dedicated POST route for activity visibility updates
- Adds online/hidden activity dots in the community UI
- Updates demo seed data with activity visibility values
- Adds tests for:
  - dropdown rendering
  - hidden/online toggle behaviour
  - last-seen tracking

## Testing

```bash
python -m pytest tests/test_activity_visibility.py -q
python -m pytest -q