### PR TITLE
Add security headers and session hardening

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -49,4 +49,50 @@ def create_app(config_name="development"):
     with app.app_context():
         db.create_all()
 
+
+    _apply_security_config(app)
+    _register_security_headers(app)
+
     return app
+
+# ---------------------------------------------------------------------------
+# Security hardening
+# ---------------------------------------------------------------------------
+
+def _apply_security_config(app):
+    """Apply safe session/cookie security defaults.
+
+    These settings do not change user flows, but they make browser-side session
+    handling safer by default.
+    """
+    app.config["SESSION_COOKIE_HTTPONLY"] = True
+    app.config["SESSION_COOKIE_SAMESITE"] = "Lax"
+    app.config["REMEMBER_COOKIE_HTTPONLY"] = True
+    app.config["REMEMBER_COOKIE_SAMESITE"] = "Lax"
+
+
+def _register_security_headers(app):
+    """Register basic browser security headers for every response."""
+    if getattr(app, "_habitwise_security_headers_registered", False):
+        return
+
+    app._habitwise_security_headers_registered = True
+
+    @app.after_request
+    def add_security_headers(response):
+        response.headers.setdefault("X-Content-Type-Options", "nosniff")
+        response.headers.setdefault("X-Frame-Options", "DENY")
+        response.headers.setdefault("Referrer-Policy", "strict-origin-when-cross-origin")
+        response.headers.setdefault(
+            "Permissions-Policy",
+            "camera=(), microphone=(), geolocation=()",
+        )
+
+        # Prevent sensitive HTML pages being stored in browser/shared caches.
+        content_type = response.headers.get("Content-Type", "")
+        if content_type.startswith("text/html"):
+            response.headers.setdefault("Cache-Control", "no-store")
+            response.headers.setdefault("Pragma", "no-cache")
+
+        return response
+

--- a/tests/test_security_headers.py
+++ b/tests/test_security_headers.py
@@ -1,0 +1,23 @@
+def test_security_headers_are_set_on_home_page(client):
+    response = client.get("/")
+
+    assert response.status_code == 200
+    assert response.headers["X-Content-Type-Options"] == "nosniff"
+    assert response.headers["X-Frame-Options"] == "DENY"
+    assert response.headers["Referrer-Policy"] == "strict-origin-when-cross-origin"
+    assert response.headers["Permissions-Policy"] == "camera=(), microphone=(), geolocation=()"
+
+
+def test_html_pages_are_not_cached(client):
+    response = client.get("/")
+
+    assert response.status_code == 200
+    assert "no-store" in response.headers["Cache-Control"]
+    assert response.headers["Pragma"] == "no-cache"
+
+
+def test_session_cookie_security_config_is_enabled(app):
+    assert app.config["SESSION_COOKIE_HTTPONLY"] is True
+    assert app.config["SESSION_COOKIE_SAMESITE"] == "Lax"
+    assert app.config["REMEMBER_COOKIE_HTTPONLY"] is True
+    assert app.config["REMEMBER_COOKIE_SAMESITE"] == "Lax"


### PR DESCRIPTION
## Summary

This PR adds a safe final security polish without changing user flows or adding dependencies.

## Changes

- Adds browser security headers:
  - `X-Content-Type-Options: nosniff`
  - `X-Frame-Options: DENY`
  - `Referrer-Policy: strict-origin-when-cross-origin`
  - `Permissions-Policy: camera=(), microphone=(), geolocation=()`
- Adds `Cache-Control: no-store` and `Pragma: no-cache` for HTML pages
- Hardens session and remember cookies:
  - `SESSION_COOKIE_HTTPONLY = True`
  - `SESSION_COOKIE_SAMESITE = "Lax"`
  - `REMEMBER_COOKIE_HTTPONLY = True`
  - `REMEMBER_COOKIE_SAMESITE = "Lax"`
- Adds tests for security headers and cookie config

## Testing

```bash
python -m pytest tests/test_security_headers.py -q
python -m pytest -q